### PR TITLE
Fix compilation with current version of AutobahnCpp

### DIFF
--- a/native_transport.hpp
+++ b/native_transport.hpp
@@ -31,7 +31,7 @@ public:
     virtual boost::future<void> disconnect() override;
     virtual bool is_connected() const override;
 
-    virtual void send(autobahn::wamp_message&& message) override;
+    virtual void send_message(autobahn::wamp_message&& message) override;
     virtual void set_pause_handler(autobahn::wamp_transport::pause_handler&& handler) override;
     virtual void set_resume_handler(autobahn::wamp_transport::resume_handler&& handler) override;
     virtual void pause() override;

--- a/native_transport.ipp
+++ b/native_transport.ipp
@@ -85,10 +85,10 @@ inline bool native_transport::is_connected() const
     return m_component_endpoint != nullptr;
 }
 
-inline void native_transport::send(autobahn::wamp_message&& message)
+inline void native_transport::send_message(autobahn::wamp_message&& message)
 {
-    auto send_message = m_server_endpoint->get_send_message_handler();
-    send_message(std::move(message.fields()), std::move(message.zone()));
+    auto send_message_handler = m_server_endpoint->get_send_message_handler();
+    send_message_handler(std::move(message.fields()), std::move(message.zone()));
 }
 
 inline void native_transport::set_pause_handler(autobahn::wamp_transport::pause_handler&& handler)


### PR DESCRIPTION
Some refactoring in AutobahnCpp resulted in an invalid override of autobahn::wamp_transport::send which obviously has been renamed to send_message.